### PR TITLE
Refactor of masternodes endpoint

### DIFF
--- a/src/routing/api.js
+++ b/src/routing/api.js
@@ -148,6 +148,39 @@ module.exports = (app) => {
         })
     })
 
+    app.get('/mncounts', (req, res) => {
+        getTierCounts = (masternodes) => {
+            var tierCounts = {
+                copper: 0,
+                silver: 0,
+                gold: 0,
+                diamond: 0,
+                platinum: 0,
+            };
+            var rewards = [];
+            for(var m = 0; m < masternodes.length; m++){
+                let node = masternodes[m];
+                if(node.tier){
+                    let tier = node.tier.toLowerCase();
+                    if(tierCounts[tier] || tierCounts[tier] === 0){
+                        tierCounts[tier] ++;
+                    }
+                }
+            }
+            res.json({
+                "num_masternodes": masternodes.length,
+                "layers": tierCounts
+            })
+        }
+        batchCall = () => {
+            rpc.listMasternodes()
+        }
+        rpc.batch(batchCall, (err, mns) => {
+            if (err) throw err
+            getTierCounts(mns[0].result)
+        })
+    })
+    
     app.get('/masternode/:address', (req, res) => {
         let address = req.params.address
         batchCall = () => {

--- a/src/routing/api.js
+++ b/src/routing/api.js
@@ -79,7 +79,6 @@ module.exports = (app) => {
         })
     })
 
-    // Get total number of connected peers
     app.get('/connectioncount', (req, res) => {
         rpc.getConnectionCount((err, response) => {
             if (err) {
@@ -93,101 +92,60 @@ module.exports = (app) => {
         })
     })
 
-    // Get masternode information
     app.get('/masternodes', (req, res) => {
-        // Start all tiers at 0
-        let masternodeTierCounts = {
-            COPPER: 0,
-            SILVER: 0,
-            GOLD: 0,
-            PLATINUM: 0,
-            DIAMOND: 0
-        };
-        // We will have two arrays for storing rewards and masternode info
-        let rewardArr = []
-
         batchCall = () => {
             rpc.listMasternodes()
         }
-        /** Gets the initial data about masternodes using a batchCall to optimize request speed
-         * @function
-         */
-        getMasternodes = () => {
-            // The batch function takes a callback function  that returns an error and masternode info
-            rpc.batch(batchCall, (err, mns) => {
-                if (err) throw err
-                // Set masternodeArray equal to the result at the 0th index
-                // Call getTierFigures to determine how many nodes of each type exist in the network
-                getTierFigures(mns[0].result)
-            })
-        }
-        getMasternodes()
 
-        /** Get's the number of nodes of each type that exist in the network
-         * @function
-         */
-        getTierFigures = (masternodeArray) => {
-            // Loop over the masternodeArray, mapping each tier
-            masternodeArray.map(node => {
-                let tier = node.tier
-                // If the layer matches, increment the number of nodes of that type by 1
-                if(masternodeTierCounts[tier]){
-                    masternodeTierCounts[tier] ++;
-                }
-            })
-            // Once all the tiers have been numbered, call getNodeBalances to find further info about each node
-            getNodeBalances(masternodeArray)
-        }
+        getAllFigures = (masternodes) => {
+            var tierCounts = {
+                copper: 0,
+                silver: 0,
+                gold: 0,
+                diamond: 0,
+                platinum: 0
+            };
+            var rewards = [];
+            for(var m = 0; m < masternodes.length; m++){
+                let node = masternodes[m];
+                
+                if(node.tier){
+                    let tier = node.tier.toLowerCase();
 
-        /** Get's balances for each node individually based on their address 
-         * @function
-         */
-        getNodeBalances = (masternodeArray) => {
-            batchCall = () => {
-                // For every masternode we will find the address and
-                for (let a in masternodeArray) {
-                    // call the getAddressBalance rpc function for each of the addresses
-                    rpc.getAddressBalance({ "addresses": [masternodeArray[a].addr] })
+                    if(tierCounts[tier] || tierCounts[tier] === 0){
+
+                        tierCounts[tier] ++;
+
+                    }
                 }
-            }
-            // Once the batch is created, call the function and use the callback function to return the data
-            rpc.batch(batchCall, (err, balanceInfo) => {
-                if (err) throw err
-                        // Once again, for every masternode in the array
-                for (let a in masternodeArray) {
-                    // We will push the object containing relevant data to the rewardArr array
-                    rewardArr.push({
-                        address: masternodeArray[a].addr,
-                        amountReceived: balanceInfo[a].result.received,
-                        balance: balanceInfo[a].result.balance,
-                        layer: masternodeArray[a].tier
+
+                let balanceInfo = rpc.getAddressBalance({ "addresses": [node.addr] });
+                if(balanceInfo && balanceInfo.result){
+                    rewards[m] = ({
+                        address: node.addr,
+                        amountReceived: balanceInfo.result.received,
+                        balance: balanceInfo.result.balance,
+                        layer: node.tier
                     })
                 }
-                // Once all the data has been pushed to the array, we can render the JSON to the client
-                renderData(masternodeArray)
-            })
+            }
+            renderData(masternodes, tierCounts, rewards);
         }
-
-        /** Renders the collective data to the client in JSON format
-         * @function
-         */
-        renderData = (masternodeArray) => {
-            // First weed out any duplicates and redefine the array of rewards as uniqRewards
-            let uniqRewards = _.uniq(rewardArr)
-            // Then return the JSON to the client
+        
+        renderData = (masternodeArray, masternodeTierCounts, rewardArr) => {
             res.json({
                 num_masternodes: masternodeArray.length,
-                'layers': {
-                    'copper': masternodeTierCounts.COPPER,
-                    'silver': masternodeTierCounts.SILVER,
-                    'gold': masternodeTierCounts.GOLD,
-                    'platinum': masternodeTierCounts.PLATINUM,
-                    'diamond': masternodeTierCounts.DIAMOND
-                },
+                'layers': masternodeTierCounts,
                 uniqRewards,
                 masternode_list: masternodeArray
             })
         }
+        
+        rpc.batch(batchCall, (err, mns) => {
+            if (err) throw err
+
+            getAllFigures(mns[0].result)
+        })
     })
 
     app.get('/masternode/:address', (req, res) => {
@@ -214,6 +172,29 @@ module.exports = (app) => {
         })
     })
 
+    app.get('/masternode/:address', (req, res) => {
+        let address = req.params.address
+        batchCall = () => {
+            rpc.listMasternodes()
+        }
+
+        rpc.batch(batchCall, (err, mns) => {
+            if (err) throw err
+
+            const masternodes = mns[0].result
+
+            // Find specific masternode
+            const masternode = masternodes.find(masternode => masternode.addr === address)
+
+            // Not found?
+            if (!masternode) {
+                return res.json("Sorry that address does not exist")
+            }
+
+            // Send reply
+            return res.json(masternode)
+        })
+    })
 
     // Return only rewards by masternodes
     app.get('/masternode-rewards', (req, res) => {

--- a/src/routing/api.js
+++ b/src/routing/api.js
@@ -169,10 +169,10 @@ module.exports = (app) => {
             }
             // Once the batch is created, call the function and use the callback function to return the data
             rpc.batch(batchCall, (err, balanceInfo) => {
-		if (err) throw err
-                // Once again, for every masternode in the array
-		for (let a in masternodeArray) {
-		    // We will push the object containing relevant data to the rewardArr array
+                if (err) throw err
+                        // Once again, for every masternode in the array
+                for (let a in masternodeArray) {
+                    // We will push the object containing relevant data to the rewardArr array
                     rewardArr.push({
                         address: masternodeArray[a].addr,
                         amountReceived: balanceInfo[a].result.received,

--- a/src/routing/api.js
+++ b/src/routing/api.js
@@ -105,7 +105,6 @@ module.exports = (app) => {
         };
         // We will have two arrays for storing rewards and masternode info
         let rewardArr = []
-        let masternodeArray = []
 
         batchCall = () => {
             rpc.listMasternodes()
@@ -118,9 +117,8 @@ module.exports = (app) => {
             rpc.batch(batchCall, (err, mns) => {
                 if (err) throw err
                 // Set masternodeArray equal to the result at the 0th index
-                masternodeArray = mns[0].result
                 // Call getTierFigures to determine how many nodes of each type exist in the network
-                getTierFigures()
+                getTierFigures(mns[0].result)
             })
         }
         getMasternodes()
@@ -128,7 +126,7 @@ module.exports = (app) => {
         /** Get's the number of nodes of each type that exist in the network
          * @function
          */
-        getTierFigures = () => {
+        getTierFigures = (masternodeArray) => {
             // Loop over the masternodeArray, mapping each tier
             masternodeArray.map(node => {
                 let tier = node.tier
@@ -138,13 +136,13 @@ module.exports = (app) => {
                 }
             })
             // Once all the tiers have been numbered, call getNodeBalances to find further info about each node
-            getNodeBalances()
+            getNodeBalances(masternodeArray)
         }
 
         /** Get's balances for each node individually based on their address 
          * @function
          */
-        getNodeBalances = () => {
+        getNodeBalances = (masternodeArray) => {
             batchCall = () => {
                 // For every masternode we will find the address and
                 for (let a in masternodeArray) {
@@ -166,14 +164,14 @@ module.exports = (app) => {
                     })
                 }
                 // Once all the data has been pushed to the array, we can render the JSON to the client
-                renderData()
+                renderData(masternodeArray)
             })
         }
 
         /** Renders the collective data to the client in JSON format
          * @function
          */
-        renderData = () => {
+        renderData = (masternodeArray) => {
             // First weed out any duplicates and redefine the array of rewards as uniqRewards
             let uniqRewards = _.uniq(rewardArr)
             // Then return the JSON to the client

--- a/src/routing/api.js
+++ b/src/routing/api.js
@@ -96,12 +96,13 @@ module.exports = (app) => {
     // Get masternode information
     app.get('/masternodes', (req, res) => {
         // Start all tiers at 0
-        let
-            copper = 0,
-            silver = 0,
-            gold = 0,
-            platinum = 0,
-            diamond = 0
+        let masternodeTierCounts = {
+            COPPER: 0,
+            SILVER: 0,
+            GOLD: 0,
+            PLATINUM: 0,
+            DIAMOND: 0
+        };
         // We will have two arrays for storing rewards and masternode info
         let rewardArr = []
         let masternodeArray = []
@@ -129,27 +130,11 @@ module.exports = (app) => {
          */
         getTierFigures = () => {
             // Loop over the masternodeArray, mapping each tier
-            masternodeArray.map(tiers => {
-                // to a variable layer
-                let layer = tiers.tier
-                // Using a switch/case statement, we can easily iterate and set each node layer's equivalent value
+            masternodeArray.map(node => {
+                let tier = node.tier
                 // If the layer matches, increment the number of nodes of that type by 1
-                switch (layer) {
-                    case 'COPPER':
-                        copper++
-                        break
-                    case 'SILVER':
-                        silver++
-                        break
-                    case 'GOLD':
-                        gold++
-                        break
-                    case 'PLATINUM':
-                        platinum++
-                        break
-                    case 'DIAMOND':
-                        diamond++
-                        break
+                if(masternodeTierCounts[tier]){
+                    masternodeTierCounts[tier] ++;
                 }
             })
             // Once all the tiers have been numbered, call getNodeBalances to find further info about each node
@@ -195,11 +180,11 @@ module.exports = (app) => {
             res.json({
                 num_masternodes: masternodeArray.length,
                 'layers': {
-                    'copper': copper,
-                    'silver': silver,
-                    'gold': gold,
-                    'platinum': platinum,
-                    'diamond': diamond
+                    'copper': masternodeTierCounts.COPPER,
+                    'silver': masternodeTierCounts.SILVER,
+                    'gold': masternodeTierCounts.GOLD,
+                    'platinum': masternodeTierCounts.PLATINUM,
+                    'diamond': masternodeTierCounts.DIAMOND
                 },
                 uniqRewards,
                 masternode_list: masternodeArray


### PR DESCRIPTION
Refactor endpoint for /masternodes/. Faster and no longer crashes.
The rpc.getAddressBalance was returning "null" for the result. I was not able to fix this here, but it no longer crashes. As a result, it instead will only add to the rewards array what it can. (So right now the rewards array stays empty)

Also, added an /mncounts/ endpoint to get the tier counts only (requested by @7h3v01c3).
